### PR TITLE
[PKGBUILD] Hotfix to support yay AUR helper

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -110,6 +110,9 @@ prepare() {
 }
 
 build() {
+  _ungoogled_archlinux_repo="$srcdir/$pkgname-archlinux-${_ungoogled_archlinux_version}"
+  _ungoogled_repo="$srcdir/$pkgname-${_ungoogled_version}"
+
   make -C chromium-launcher-$_launcher_ver
 
   cd "$srcdir/chromium-${_chromium_version}"


### PR DESCRIPTION
Per my most recent comment in #1, this hotfix addresses the an issue reported in the commet located at https://aur.archlinux.org/packages/ungoogled-chromium-archlinux/#comment-693490:
> This time, "cat" cannot find the "/flags.archlinux.gn" file

The problem has to do with how https://github.com/Jguer/yay runs `prepare` and `build` and is related to the this `yay` issue specifically https://github.com/Jguer/yay/issues/893. `yay` is very popular (it's what I personally use) and we should strive to support it.

Although I'm not a fan of redefining variables like this, I know it's an Arch best practice to avoid introducing additional functions. Please feel free to change if a cleaner solution comes to mind.