### PR TITLE
PKGBUILD: Fix chromedriver symlink

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -155,7 +155,7 @@ package() {
 
   install -D out/Default/chrome "$pkgdir/usr/lib/chromium/chromium"
   install -Dm4755 out/Default/chrome_sandbox "$pkgdir/usr/lib/chromium/chrome-sandbox"
-  ln -s /usr/lib/$pkgname/chromedriver "$pkgdir/usr/bin/chromedriver"
+  ln -s /usr/lib/chromium/chromedriver "$pkgdir/usr/bin/chromedriver"
 
   install -Dm644 chrome/installer/linux/common/desktop.template \
     "$pkgdir/usr/share/applications/chromium.desktop"


### PR DESCRIPTION
Set the link source to `/usr/lib/chromium/chromedriver` instead of the invalid path `/usr/lib/ungoogled-chromium/chromedriver`.

I believe this was mentioned in another issue before.