### PR TITLE
Fix compile error caused by gcc 9

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -79,6 +79,8 @@ prepare() {
 
   cd "$srcdir/chromium-${_chromium_version}"
 
+  msg2 'Fixing compile time bug on gcc9'
+  patch -p1 --ignore-whitespace -i ../../gcc-9-fix.patch --no-backup-if-mismatch
   msg2 'Pruning binaries'
   python "$_utils/prune_binaries.py" ./ "$_ungoogled_repo/pruning.list"
   msg2 'Applying patches'

--- a/gcc-9-fix.patch
+++ b/gcc-9-fix.patch
@@ -1,0 +1,22 @@
+Bug: https://bugs.gentoo.org/686982
+
+TabStripModelChange has a defaulted default constructor and a const data member
+without a user-defined default constructor.  This leads to a bug:
+
+error: defaulting this default constructor would delete it after
+its first declaration
+
+We declare the data member as non-const instead.
+
+--- a/chrome/browser/ui/tabs/tab_strip_model_observer.h
++++ b/chrome/browser/ui/tabs/tab_strip_model_observer.h
+@@ -103,7 +103,7 @@ class TabStripModelChange {
+ 
+  private:
+   const Type type_ = kSelectionOnly;
+-  const std::vector<Delta> deltas_;
++  std::vector<Delta> deltas_;
+ 
+   DISALLOW_COPY_AND_ASSIGN(TabStripModelChange);
+ };
+


### PR DESCRIPTION
This is the same error as https://github.com/ungoogled-software/ungoogled-chromium-debian/issues/7. It hits Arch today since they updated gcc to 9. I have verified that the attached patch fixed the error on Arch.