### PR TITLE
Hotfix for nonexistent git source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 pkg
 src
 *.tar.*
+ungoogled-chromium-archlinux

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,6 +9,7 @@
 pkgname=ungoogled-chromium
 # Commit or tag for the upstream ungoogled-chromium repo
 _ungoogled_version='76.0.3809.132-1'
+_ungoogled_archlinux_version=943c4a3abc7a6d88a01bd9d51bdce9b9919064c2
 _chromium_version=$(curl -sL https://raw.githubusercontent.com/Eloston/ungoogled-chromium/${_ungoogled_version}/chromium_version.txt)
 _ungoogled_revision=$(curl -sL https://raw.githubusercontent.com/Eloston/ungoogled-chromium/${_ungoogled_version}/revision.txt)
 pkgver=${_chromium_version}
@@ -35,7 +36,7 @@ provides=('chromium')
 conflicts=('chromium')
 source=(https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${_chromium_version}.tar.xz
         chromium-launcher-$_launcher_ver.tar.gz::https://github.com/foutrelis/chromium-launcher/archive/v$_launcher_ver.tar.gz
-        "git+https://github.com/ungoogled-software/ungoogled-chromium-archlinux#tag=${_ungoogled_version}"
+        "git+https://github.com/ungoogled-software/ungoogled-chromium-archlinux.git#commit=${_ungoogled_archlinux_version}"
         "git+https://github.com/Eloston/ungoogled-chromium#tag=${_ungoogled_version}")
 sha256sums=($(curl -sL https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${_chromium_version}.tar.xz.hashes | grep sha256 | cut -d ' ' -f3)
             '04917e3cd4307d8e31bfb0027a5dce6d086edb10ff8a716024fbb8bb0c7dccf1'


### PR DESCRIPTION
The current tip of the tree is not building with `makepkg` due to `ungoogled-chromium-archlinux` source being set to a nonexistent tag, https://github.com/ungoogled-software/ungoogled-chromium-archlinux/blob/c8bbde956f02a2fa0e587dadc170a99ec3f97b79/PKGBUILD#L38. `makepkg` output:

```
  -> Cloning ungoogled-chromium-archlinux git repo...
Cloning into bare repository '/home/neeks/Development/archlinux/ungoogled-chromium-archlinux/ungoogled-chromium-archlinux'...
remote: Enumerating objects: 96, done.
remote: Counting objects: 100% (96/96), done.
remote: Compressing objects: 100% (81/81), done.
remote: Total 352 (delta 40), reused 55 (delta 14), pack-reused 256
Receiving objects: 100% (352/352), 126.12 KiB | 2.74 MiB/s, done.
Resolving deltas: 100% (147/147), done.
  -> Updating ungoogled-chromium git repo...
Fetching origin
==> Validating source files with sha256sums...
    chromium-76.0.3809.132.tar.xz ... Passed
    chromium-launcher-6.tar.gz ... Passed
    ungoogled-chromium-archlinux ... Skipped
    ungoogled-chromium ... Skipped
==> Extracting sources...
  -> Extracting chromium-76.0.3809.132.tar.xz with bsdtar
  -> Extracting chromium-launcher-6.tar.gz with bsdtar
  -> Creating working copy of ungoogled-chromium-archlinux git repo...
Cloning into 'ungoogled-chromium-archlinux'...
done.
fatal: '76.0.3809.132-1' is not a commit and a branch 'makepkg' cannot be created from it
```

This PR reintroduces the `_ungoogled_archlinux_version` variable and updates the new git source to reference it. @tangalbert919 thoughts?

Additionally added the new git directory, `ungoogled-chromium-archlinux`, to `.gitignore`

---

Off-topic: @Eloston I'll have some downtime next week and will attempt some `PKGBUILD` document, I'll open a new issue or PR to discuss/review