### PR TITLE
Convert PKGBUILD to a template

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,9 +28,10 @@ validate_with_source_task:
 
 validate_makepkg_task:
     validate_makepkg_script:
-        - chmod -R 777 .
+        - git submodule update --init --recursive
         - ./generate_pkgbuild.py > PKGBUILD
         - pacman -Sy
+        - chmod -R 777 .
         - sudo -u nobody makepkg --cleanbuild --syncdeps --nobuild --noconfirm
 
 # vim: set expandtab shiftwidth=4 softtabstop=4:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,6 +29,7 @@ validate_with_source_task:
 validate_makepkg_task:
     validate_makepkg_script:
         - chmod -R 777 .
+        - ./generate_pkgbuild.py > PKGBUILD
         - pacman -Sy
         - sudo -u nobody makepkg --cleanbuild --syncdeps --nobuild --noconfirm
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ pkg
 src
 *.tar.*
 ungoogled-chromium-archlinux
+PKGBUILD

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 pkg
 src
 *.tar.*
-ungoogled-chromium-archlinux
-PKGBUILD
+/ungoogled-chromium-archlinux
+/PKGBUILD

--- a/PKGBUILD.in
+++ b/PKGBUILD.in
@@ -7,11 +7,9 @@
 # Contributor: Daniel J Griffiths <ghost1227@archlinux.us>
 
 pkgname=ungoogled-chromium
-# Commit or tag for the upstream ungoogled-chromium repo
-_ungoogled_version='77.0.3865.90-1'
-_ungoogled_archlinux_version=91ddb32901286c7e339152118b1e622a0d5dafda
-_chromium_version=$(curl -sL https://raw.githubusercontent.com/Eloston/ungoogled-chromium/${_ungoogled_version}/chromium_version.txt)
-_ungoogled_revision=$(curl -sL https://raw.githubusercontent.com/Eloston/ungoogled-chromium/${_ungoogled_version}/revision.txt)
+_chromium_version=$$PKGBUILD_TEMPLATE{chromium_version}
+_ungoogled_revision=$$PKGBUILD_TEMPLATE{ungoogled_revision}
+_ungoogled_version="${_chromium_version}-${_ungoogled_revision}"
 pkgver=${_chromium_version}
 _ungoogled_archlinux_pkgrel=0
 pkgrel=$((_ungoogled_revision + _ungoogled_archlinux_pkgrel))
@@ -36,7 +34,7 @@ provides=('chromium')
 conflicts=('chromium')
 source=(https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${_chromium_version}.tar.xz
         chromium-launcher-$_launcher_ver.tar.gz::https://github.com/foutrelis/chromium-launcher/archive/v$_launcher_ver.tar.gz
-        "git+https://github.com/ungoogled-software/ungoogled-chromium-archlinux.git#commit=${_ungoogled_archlinux_version}"
+        "$$PKGBUILD_TEMPLATE{archlinux_git_source}"
         "git+https://github.com/Eloston/ungoogled-chromium#tag=${_ungoogled_version}")
 sha256sums=($(curl -sL https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${_chromium_version}.tar.xz.hashes | grep sha256 | cut -d ' ' -f3)
             '04917e3cd4307d8e31bfb0027a5dce6d086edb10ff8a716024fbb8bb0c7dccf1'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Alternatively, [get builds from the Contributor Binaries website](//ungoogled-so
 
 ## Building
 
-You only need to download the PKGBUILD from this repository. After that, run this command:
+Download the PKGBUILD file from the `pkgbuild` branch. After that, run this command:
 
 ```
 makepkg
@@ -63,8 +63,6 @@ cd ../../
 
 # Use git to add changes and commit
 ```
-
-Afterwards, update `_ungoogled_version` in PKGBUILD to the same tag the submodule is using (`cd` into the submodule, then use `git describe` to get the needed tag).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ cd ../../
 # Use git to add changes and commit
 ```
 
+### Building locally
+
+You can build locally by running:
+
+```sh
+generate_pkgbuild.py > PKGBUILD
+makepkg
+```
+
 ## License
 
 See [LICENSE](LICENSE)

--- a/generate_pkgbuild.py
+++ b/generate_pkgbuild.py
@@ -72,18 +72,13 @@ def main():
     ungoogled_repo = root_dir / 'ungoogled-chromium'
 
     if args.prod:
-        archlinux_git_source = _PRODUCTION_URL.format(
-            commit=_get_current_commit(),
+        archlinux_git_source = _PRODUCTION_URL + '#commit={commit}'.format(
+            commit=_get_current_commit()
         )
     else:
         if not args.force and _unstaged_changes():
             parser.error('There are unstaged changes in git; please commit them or add --force')
-        archlinux_git_source = 'git+file://{}'.format(
-            Path(root_dir, '.git').resolve().as_posix()
-        )
-    archlinux_git_source += '#commit={commit}'.format(
-        commit=_get_current_commit()
-    )
+        archlinux_git_source = Path(root_dir).resolve().as_posix()
 
     chromium_version = (ungoogled_repo / 'chromium_version.txt').read_text(encoding=_ENCODING).strip()
     ungoogled_revision = (ungoogled_repo / 'revision.txt').read_text(encoding=_ENCODING).strip()

--- a/generate_pkgbuild.py
+++ b/generate_pkgbuild.py
@@ -1,0 +1,104 @@
+#!/usr/bin/python3 -B
+# -*- coding: UTF-8 -*-
+
+# Copyright (c) 2019 The ungoogled-chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+"""
+Generates PKGBUILD and print to stdout
+"""
+
+from pathlib import Path
+import argparse
+import re
+import string
+import subprocess
+
+_PRODUCTION_URL = 'git+https://github.com/ungoogled-software/ungoogled-chromium-archlinux.git'
+_ENCODING = 'UTF-8'
+
+# Classes
+
+class _BuildFileStringTemplate(string.Template):
+    """
+    Custom string substitution class
+
+    Inspired by
+    http://stackoverflow.com/questions/12768107/string-substitutions-using-templates-in-python
+    """
+
+    pattern = r"""
+    {delim}(?:
+      (?P<escaped>{delim}) |
+      _(?P<named>{id})      |
+      {{(?P<braced>{id})}}   |
+      (?P<invalid>{delim}((?!_)|(?!{{)))
+    )
+    """.format(
+        delim=re.escape("$$PKGBUILD_TEMPLATE"), id=string.Template.idpattern)
+
+
+# Methods
+
+def _get_current_commit():
+    return subprocess.run(
+        ('git', 'rev-parse', '--verify', 'HEAD'),
+        check=True,
+        capture_output=True,
+        encoding=_ENCODING,
+    ).stdout.strip()
+
+def _unstaged_changes():
+    """Returns True if there are unstaged changes; False otherwise"""
+    return subprocess.run(
+        ('git', 'diff', '--exit-code'),
+        stdout=subprocess.DEVNULL,
+    ).returncode != 0
+
+def main():
+    """CLI Entrypoint"""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--prod', action='store_true',
+                        help=(
+                            'Add this flag to use the production '
+                            'ungoogled-chromium-archlinux repo for building'))
+    parser.add_argument('--force', '-f', action='store_true',
+                        help=(
+                            'Force PKGBUILD generation even if there '
+                            'are unstaged changes.'))
+    args = parser.parse_args()
+
+    root_dir = Path(__file__).resolve().parent
+    ungoogled_repo = root_dir / 'ungoogled-chromium'
+
+    if args.prod:
+        archlinux_git_source = _PRODUCTION_URL.format(
+            commit=_get_current_commit(),
+        )
+    else:
+        if not args.force and _unstaged_changes():
+            parser.error('There are unstaged changes in git; please commit them or add --force')
+        archlinux_git_source = 'git+file://{}'.format(
+            Path(root_dir, '.git').resolve().as_posix()
+        )
+    archlinux_git_source += '#commit={commit}'.format(
+        commit=_get_current_commit()
+    )
+
+    chromium_version = (ungoogled_repo / 'chromium_version.txt').read_text(encoding=_ENCODING).strip()
+    ungoogled_revision = (ungoogled_repo / 'revision.txt').read_text(encoding=_ENCODING).strip()
+
+    # Print PKGBUILD to stdout
+    print(
+        _BuildFileStringTemplate(
+            Path(root_dir, 'PKGBUILD.in').read_text(encoding=_ENCODING)
+        ).substitute(
+            archlinux_git_source=archlinux_git_source,
+            chromium_version=chromium_version,
+            ungoogled_revision=ungoogled_revision,
+        )
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/generate_pkgbuild.py
+++ b/generate_pkgbuild.py
@@ -72,13 +72,11 @@ def main():
     ungoogled_repo = root_dir / 'ungoogled-chromium'
 
     if args.prod:
-        archlinux_git_source = _PRODUCTION_URL.format(
-            commit=_get_current_commit(),
-        )
+        archlinux_git_source = _PRODUCTION_URL
     else:
         if not args.force and _unstaged_changes():
             parser.error('There are unstaged changes in git; please commit them or add --force')
-        archlinux_git_source = 'git+file://{}'.format(
+        archlinux_git_source = '$pkgname-archlinux::git+file://{}'.format(
             Path(root_dir, '.git').resolve().as_posix()
         )
     archlinux_git_source += '#commit={commit}'.format(

--- a/generate_pkgbuild.py
+++ b/generate_pkgbuild.py
@@ -72,13 +72,18 @@ def main():
     ungoogled_repo = root_dir / 'ungoogled-chromium'
 
     if args.prod:
-        archlinux_git_source = _PRODUCTION_URL + '#commit={commit}'.format(
-            commit=_get_current_commit()
+        archlinux_git_source = _PRODUCTION_URL.format(
+            commit=_get_current_commit(),
         )
     else:
         if not args.force and _unstaged_changes():
             parser.error('There are unstaged changes in git; please commit them or add --force')
-        archlinux_git_source = Path(root_dir).resolve().as_posix()
+        archlinux_git_source = 'git+file://{}'.format(
+            Path(root_dir, '.git').resolve().as_posix()
+        )
+    archlinux_git_source += '#commit={commit}'.format(
+        commit=_get_current_commit()
+    )
 
     chromium_version = (ungoogled_repo / 'chromium_version.txt').read_text(encoding=_ENCODING).strip()
     ungoogled_revision = (ungoogled_repo / 'revision.txt').read_text(encoding=_ENCODING).strip()


### PR DESCRIPTION
Converts PKGBUILD to a template `PKGBUILD.in`. This is my take on fixing #34.

The implementation is not complete yet because there's no CI task to push updates to a `pkgbuild` branch.

I'm open to suggestions on my approach. I don't have an Arch Linux machine to test this, so feel free to take over this PR and push new commits to my branch (but let us know first before you do).