### PR TITLE
Add two step build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,18 +2,17 @@ name: Ungoogled-chromium-archlinux build
 on: [push, pull_request]
 
 jobs:
-  build:
+  build_part_1:
     env:
         container_name: archlinuxlatest_47dabf
         XHYVE_CPU_COUNT: 4
-        XHYVE_MEMORY_SIZE: 10240
+        XHYVE_MEMORY_SIZE: 11264
     name: Build Chromium
     runs-on: macos-latest
     strategy:
         fail-fast: false
         matrix:
             target: [release,debug]
-
     steps:
       - name: Check Environment
         run: |
@@ -83,13 +82,141 @@ jobs:
         run: |
             docker-machine env default
             eval "$(docker-machine env default)"
-            docker exec ${container_name} bash -c "cd ungoogled-chromium-archlinux && sed -i -e 's/is_debug=false/is_debug=true/g' flags.archlinux.gn && sed -i -e 's/blink_symbol_level=0/blink_symbol_level=1/g' flags.archlinux.gn && sed -i -e 's/symbol_level=0/symbol_level=1/g' flags.archlinux.gn"
-            docker exec ${container_name} bash -c 'cat ungoogled-chromium-archlinux/flags.archlinux.gn'
-      - name: Build
+            docker exec ${container_name} bash -c "cd ungoogled-chromium-archlinux && chmod +x .github/workflows/debug.sh && .github/workflows/debug.sh"
+            docker exec ${container_name} bash -c 'cat ungoogled-chromium-archlinux/PKGBUILD'
+      - name: Build part 1
+        timeout-minutes: 360
+        continue-on-error: true
         run: |
             docker-machine env default
             eval "$(docker-machine env default)"
             docker exec ${container_name} chown builduser -R ungoogled-chromium-archlinux
+            docker exec ${container_name} sudo -u builduser bash -c 'cd ungoogled-chromium-archlinux && timeout -k 320m -s SIGINT 310m makepkg -s --noconfirm || true'
+      - name: Move artifact
+        run: |
+            docker-machine env default
+            eval "$(docker-machine env default)"
+            docker exec ${container_name} bash -c 'ps aux | grep ninja'
+            docker exec ${container_name} bash -c 'ls -la ungoogled-chromium-archlinux'
+            docker exec ${container_name} bash -c 'mkdir ${HOME}/artifact && cd ungoogled-chromium-archlinux && source ./.github/workflows/get_chromium_version && cd src && tar -cz -H posix --atime-preserve -C $(pwd) -f ${HOME}/artifact/out.tar.gz chromium-${_chromium_version}'
+            docker-machine scp -r docker@default:/home/docker/work/_temp/_github_home/artifact ..
+            ls -la ..
+            cd ../artifact
+      - uses: actions/upload-artifact@v1
+        name: Upload artifact
+        with:
+          name: ${{matrix.target}}_intermediate_build
+          path: ../artifact/
+
+  build_part_2:
+    env:
+        container_name: archlinuxlatest_47dabf
+        XHYVE_CPU_COUNT: 4
+        XHYVE_MEMORY_SIZE: 11264
+        repo_name: ungoogled-software/ungoogled-chromium-archlinux
+    name: Build Chromium
+    needs: build_part_1
+    runs-on: macos-latest
+    if: always()
+    strategy:
+        fail-fast: false
+        matrix:
+            target: [release,debug]
+    steps:
+      - name: Check Environment
+        run: |
+            pwd
+            uname -r
+            system_profiler SPHardwareDataType
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: |
+            auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+            git submodule sync --recursive
+            git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+      - uses: actions/download-artifact@v1
+        name: Download artifact
+        with:
+            name: ${{matrix.target}}_intermediate_build
+            path: .
+      - name: Delete artifact (Not yet working)
+        env:
+            artifact_name: ${{matrix.target}}_intermediate_build
+        run: |
+            ls -la .
+            echo $(curl --request GET --url "https://api.github.com/repos/${repo_name}/actions/runs/${{ github.run_id }}/artifacts" --header 'authorization: Bearer ${{ github.token }}')
+            # artifact_id=$(curl --request GET --url "https://api.github.com/repos/${repo_name}/actions/runs/${{ github.run_id }}/artifacts" --header 'authorization: Bearer ${{ github.token }}' | jq -r -c --arg name "${artifact_name}" '.artifacts[] | select(.name == $name) | .id')
+            # echo ${artifact_id}
+            # response=$(curl --request DELETE --url "https://api.github.com/repos/${repo_name}/actions/artifacts/${artifact_id}" --header 'authorization: Bearer ${{ github.token }}')
+            # echo ${response}
+            # if [[ $response == *"200"* ]] || [[ $response == *"202"* ]] || [[ $response == *"204"* ]]; then echo "Artifact deleted"; else exit 1; fi
+      - name: Install Docker
+        run: |
+            brew install docker docker-compose docker-machine xhyve docker-machine-driver-xhyve
+            sudo chown root:wheel $(brew --prefix)/opt/docker-machine-driver-xhyve/bin/docker-machine-driver-xhyve
+            sudo chmod u+s $(brew --prefix)/opt/docker-machine-driver-xhyve/bin/docker-machine-driver-xhyve
+      - name: Create Docker Machine
+        env:
+            machine_config_path: /Users/runner/.docker/machine/machines/default
+        run: |
+            mkdir -p ~/.docker/machine/cache
+            curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.5/boot2docker.iso
+            for i in $(seq 1 10); do docker-machine create --driver xhyve default && s=0 && break || sudo kill -9 `ps aux | grep xhyve | grep -v grep | awk '{print $2}'` && sudo rm -rf ${machine_config_path} && s=$? && sleep 15; done; (exit $s)    # Retry 10 times before abort
+            docker-machine ssh default pwd
+            docker-machine ssh default id -un
+            docker-machine ssh default mkdir -p /home/docker/work/_temp /home/docker/work/_actions /home/docker/work/_temp/_github_home /home/docker/work/_temp/_github_workflow
+      - name: Start Docker
+        # Security profile is from https://github.com/Zenika/alpine-chrome/blob/master/chrome.json. The original file is licensed under MIT.
+        run: |
+            docker-machine env default
+            eval "$(docker-machine env default)"
+            docker version --format '{{.Server.APIVersion}}'
+            docker version --format '{{.Client.APIVersion}}'
+            docker ps --all --quiet --no-trunc --filter "label=488dfb"
+            docker network prune --force --filter "label=488dfb"
+            docker network create --label 488dfb github_network_28ec84219b9a42c98a67ea807a1d376e
+            docker pull archlinux:latest
+            docker volume create --name ${container_name}_local_volume
+            docker create --name ${container_name} --label 488dfb --workdir /__w/ungoogled-chromium-archlinux/ungoogled-chromium-archlinux --network github_network_28ec84219b9a42c98a67ea807a1d376e  -e "HOME=/github/home" -e GITHUB_ACTIONS=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "${container_name}_local_volume":"/__w" -v "/home/docker/work/_temp":"/__w/_temp" -v "/home/docker/work/_actions":"/__w/_actions" -v "/home/docker/work/_temp/_github_home":"/github/home" -v "/home/docker/work/_temp/_github_workflow":"/github/workflow" --entrypoint "tail" --security-opt seccomp=./.github/workflows/chromium.json archlinux:latest "-f" "/dev/null"
+            docker ps --all
+            docker inspect --format "{{range .Config.Env}}{{println .}}{{end}}" ${container_name}
+            docker start ${container_name}
+      - name: Install dependencies
+        run: |
+            docker-machine env default
+            eval "$(docker-machine env default)"
+            docker exec ${container_name} pacman -Sy --noconfirm
+            docker exec ${container_name} pacman -S --noconfirm gnu-free-fonts
+            docker exec ${container_name} pacman -S --noconfirm --needed base base-devel git
+      - name: Copy repository to Docker
+        run: |
+            docker-machine env default
+            eval "$(docker-machine env default)"
+            docker-machine scp -r ../ungoogled-chromium-archlinux docker@default:/home/docker/work/_temp/_github_home
+            docker exec ${container_name} bash -c 'cp -r ${HOME}/ungoogled-chromium-archlinux . && rm -rf ${HOME}/ungoogled-chromium-archlinux'
+      - name: Create build user
+        run: |
+            docker-machine env default
+            eval "$(docker-machine env default)"
+            docker exec ${container_name} useradd builduser -m
+            docker exec ${container_name} passwd -d builduser
+            docker exec ${container_name} bash -c "printf 'builduser ALL=(ALL) ALL\n' | tee -a /etc/sudoers"
+      - name: Replace gn parameters if DEBUG
+        if: matrix.target == 'debug'
+        run: |
+            docker-machine env default
+            eval "$(docker-machine env default)"
+            docker exec ${container_name} bash -c "cd ungoogled-chromium-archlinux && chmod +x .github/workflows/debug.sh && .github/workflows/debug.sh"
+            docker exec ${container_name} bash -c 'cat ungoogled-chromium-archlinux/PKGBUILD'
+      - name: Build second part
+        run: |
+            docker-machine env default
+            eval "$(docker-machine env default)"
+            docker exec ${container_name} chown builduser -R ungoogled-chromium-archlinux
+            docker exec ${container_name} sudo -u builduser bash -c 'cd ungoogled-chromium-archlinux && sed -i -e '\''/out\/Default\/args.gn/d'\'' -e '\''/gn gen/d'\'' PKGBUILD'
+            docker exec ${container_name} sudo -u builduser bash -c 'cd ungoogled-chromium-archlinux && sed -i -e '\''/# Assemble GN flags/a \ \ cd .. && rm -rf "chromium-$pkgver" && tar -xzpf ../out.tar.gz --same-owner -C . && cd "chromium-$pkgver"'\'' PKGBUILD'
+            docker exec ${container_name} sudo -u builduser bash -c 'cat ungoogled-chromium-archlinux/PKGBUILD'
             docker exec ${container_name} sudo -u builduser bash -c 'cd ungoogled-chromium-archlinux && makepkg -s --noconfirm' # Clone and build a package
       - name: Install and Test run
         run: |

--- a/.github/workflows/debug.sh
+++ b/.github/workflows/debug.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eux -o pipefail
+
+
+# For debugging script
+sed -i '/# Assemble GN flags/a \ \ cat "$_ungoogled_archlinux_repo/flags.archlinux.gn"' PKGBUILD
+
+# Remove jumbo
+# sed -i '/# Assemble GN flags/a \ \ sed -i -e '\''/use_jumbo_build=/d'\'' -e '\''/jumbo_file_merge_limit=/d'\'' "$_ungoogled_archlinux_repo/flags.archlinux.gn"' PKGBUILD
+
+# Add debug flags
+sed -i '/# Assemble GN flags/a \ \ sed -i -e '\''s/is_debug=false/is_debug=true/g'\'' -e '\''s/blink_symbol_level=0/blink_symbol_level=1/g'\'' -e '\''s/symbol_level=0/symbol_level=1/g'\'' "$_ungoogled_archlinux_repo/flags.archlinux.gn"' PKGBUILD

--- a/.github/workflows/get_chromium_version
+++ b/.github/workflows/get_chromium_version
@@ -1,0 +1,2 @@
+_ungoogled_version=$(grep "_ungoogled_version=" PKGBUILD | cut -d\' -f2)
+_chromium_version=$(curl -sL https://raw.githubusercontent.com/Eloston/ungoogled-chromium/${_ungoogled_version}/chromium_version.txt)


### PR DESCRIPTION
This is to solve the timeout problem since jumbo has been removed. I have tested this workflow and successfully built v80 release version [here](https://github.com/wchen342/ungoogled-chromium-archlinux/actions/runs/38707508). The total build time is a remarkable 10h12m, but it is certainly doable.

There are, however, some pitfalls, mainly caused by the still in development Github Actions API. So it is **very important** to notice the following:

 - each run will generate and upload an intermediate artifact of ~1.2GB (2.4GB if counte debug build), which contains the processed chromium source codes (by processed I mean after binary pruning, domain substitution, etc.) which is around 800MB + the `out/Default` folder which is around `300MB` compressed. Because there is no `delete-artifact` action to use at this time and listing artifacts from current run doesn't work (I have filled an issue to Actions), it is very important that **the generated intermediate artifact is deleted manually** after the run. There is a vague upper limit of 55GB storage space for artifacts so technically we can run 50 runs before running out of space, but it needs to be cleaned periodically.
 - Because of a bug in the UI or a bad design probably, since I used `if: always()` in the second job, once the second job starts running the `cancel workflow` button in the right-top corner will not work anymore. The only way it will stop is it encouters an error, finishes or timeout.

By the way, the intermediate file size can be cut to 300MB if the domain subsitution/patching python scripts can preserve file modification times for the source codes. The reason I need to compress the whole source code folder is because `ninja` will try to regenerate everything that has been modified since last run, which, unfortunately, including those processed files.