### PR TITLE
CI: Fix failing prepare stage

### DIFF
--- a/.github/workflows/build/env.sh
+++ b/.github/workflows/build/env.sh
@@ -5,6 +5,13 @@ shopt -s dotglob
 echo "==> Installing required packages"
 pacman -Syu --noconfirm jq coreutils
 
+# Work-around the issue with glibc 2.33 on old Docker engines
+# Extract files directly as pacman is also affected by the issue
+# See https://github.com/lxqt/lxqt-panel/pull/1562
+patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst
+curl -LO https://repo.archlinuxcn.org/x86_64/$patched_glibc
+bsdtar -C / -xvf $patched_glibc
+
 echo "==> Copying build files..."
 cp -r * /home/build
 chown -R build /home/build

--- a/.github/workflows/build/env.sh
+++ b/.github/workflows/build/env.sh
@@ -11,6 +11,7 @@ pacman -Syu --noconfirm jq coreutils
 patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst
 curl -LO https://repo.archlinuxcn.org/x86_64/$patched_glibc
 bsdtar -C / -xvf $patched_glibc
+rm $patched_glibc
 
 echo "==> Copying build files..."
 cp -r * /home/build


### PR DESCRIPTION
A version incompatibillity in githubs docker image causes the workflow to fail, this change should get past said error temporarily