### PR TITLE
README: Fix OBS links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ In the AUR there are multiple ungoogled-chromium flavors:
 You can get pre-built binaries from the following sources:
 
 - [Contributor Binaries Source](//ungoogled-software.github.io/ungoogled-chromium-binaries/)
-- [OBS Production Project](//build.opensuse.org/project/show/home:ungoogled_chromium/ungoogled-chromium-arch)
-- [OBS Development Project](//build.opensuse.org/project/show/home:ungoogled_chromium:testing/ungoogled-chromium-arch)
+- [OBS Production Project](https://build.opensuse.org/packages/ungoogled-chromium-arch/job_history/home:ungoogled_chromium/Arch/x86_64)
+- [OBS Development Project](https://build.opensuse.org/packages/ungoogled-chromium-arch/job_history/home:ungoogled_chromium:testing/Arch/x86_64)
 
 **OBS Repository:**
 


### PR DESCRIPTION
Currently the links specified in the README result in a 404, this pull request replaces them with the job history
for x86_64 builds﻿
