### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,10 @@ Use these commands to add the OBS repository:
 
 ```sh
 curl -s 'https://download.opensuse.org/repositories/home:/ungoogled_chromium/Arch/x86_64/home_ungoogled_chromium_Arch.key' | sudo pacman-key -a -
-sudo cat >> /etc/pacman.conf << 'EOF'
-
+echo '
 [home_ungoogled_chromium_Arch]
 SigLevel = Required TrustAll
-Server = https://download.opensuse.org/repositories/home:/ungoogled_chromium/Arch/$arch
-EOF
+Server = https://download.opensuse.org/repositories/home:/ungoogled_chromium/Arch/$arch' | sudo tee --append /etc/pacman.conf
 sudo pacman -Sy
 ```
 


### PR DESCRIPTION
When using `sudo` and redirecting the output, the redirection is performed by the shell and has thus just user permissions (usually not root). Thus the redirection to /etc/pacman.conf fails.
I propose to use a pipe with `sudo tee -a` instead.