### PR TITLE
Enable HEVC decoding support

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -44,7 +44,8 @@ source=(https://commondatastorage.googleapis.com/chromium-browser-official/chrom
         enable-GlobalMediaControlsCastStartStop.patch
         fix-TFLite-build-on-linux-with-system-zlib.patch
         angle-wayland-include-protocol.patch
-        fix-debug-crash-and-log-spam-with-GTK3-Wayland.patch)
+        fix-debug-crash-and-log-spam-with-GTK3-Wayland.patch
+        remove-main-main10-profile-limit.patch)
 sha256sums=('1cba0527c951e3c506ade96cf6ec2507ee9d43661764731ed896348182369262'
             '7f6b3397aee0b659c5964a6419f2cdf28e2b19e16700da4613f3aa9c7dde876d'
             '213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a'
@@ -57,7 +58,8 @@ sha256sums=('1cba0527c951e3c506ade96cf6ec2507ee9d43661764731ed896348182369262'
             '779fb13f2494209d3a7f1f23a823e59b9dded601866d3ab095937a1a04e19ac6'
             '5db1fae8a452774b5b177e493a2d1a435b980137b16ed74616d1fb86fe342ec7'
             'cd0d9d2a1d6a522d47c3c0891dabe4ad72eabbebc0fe5642b9e22efa3d5ee572'
-            'a9a30d16ad6b0689c2c4a85a3c508f49254fc8e69e791a45302673812461eb58')
+            'a9a30d16ad6b0689c2c4a85a3c508f49254fc8e69e791a45302673812461eb58'
+            'dc9323223c8de0d70413725c3744f91835064feb890c415f846a995073fee20b')
 
 # Possible replacements are listed in build/linux/unbundle/replace_gn_files.py
 # Keys are the names in the above script; values are the dependencies in Arch
@@ -142,6 +144,9 @@ prepare() {
   # VAAPI wayland support (https://github.com/ungoogled-software/ungoogled-chromium-archlinux/issues/161)
   patch -Np1 -i ../ozone-add-va-api-support-to-wayland.patch
 
+  # Enable HEVC decoding
+  patch -Np1 -i ../remove-main-main10-profile-limit.patch
+
   # Ungoogled Chromium changes
   _ungoogled_repo="$srcdir/$pkgname-$_uc_ver"
   _utils="${_ungoogled_repo}/utils"
@@ -202,6 +207,8 @@ build() {
     'use_custom_libcxx=false'
     'enable_widevine=true'
     'use_vaapi=true'
+    'enable_platform_hevc=true'
+    'enable_hevc_parser_and_hw_decoder=true'
   )
 
   if [[ -n ${_system_libs[icu]+set} ]]; then

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -59,7 +59,7 @@ sha256sums=('1cba0527c951e3c506ade96cf6ec2507ee9d43661764731ed896348182369262'
             '5db1fae8a452774b5b177e493a2d1a435b980137b16ed74616d1fb86fe342ec7'
             'cd0d9d2a1d6a522d47c3c0891dabe4ad72eabbebc0fe5642b9e22efa3d5ee572'
             'a9a30d16ad6b0689c2c4a85a3c508f49254fc8e69e791a45302673812461eb58'
-            'dc9323223c8de0d70413725c3744f91835064feb890c415f846a995073fee20b')
+            '01ba9fd3f791960aa3e803de4a101084c674ce8bfbaf389953aacc6beedd66dc')
 
 # Possible replacements are listed in build/linux/unbundle/replace_gn_files.py
 # Keys are the names in the above script; values are the dependencies in Arch
@@ -144,7 +144,7 @@ prepare() {
   # VAAPI wayland support (https://github.com/ungoogled-software/ungoogled-chromium-archlinux/issues/161)
   patch -Np1 -i ../ozone-add-va-api-support-to-wayland.patch
 
-  # Enable HEVC decoding
+  # Remove HEVC profile limits
   patch -Np1 -i ../remove-main-main10-profile-limit.patch
 
   # Ungoogled Chromium changes

--- a/remove-main-main10-profile-limit.patch
+++ b/remove-main-main10-profile-limit.patch
@@ -1,0 +1,46 @@
+From f8a2a66134bb127bfde54db3e0575b7636e93441 Mon Sep 17 00:00:00 2001
+From: Sta Zhu <zhusidayoyo@hotmail.com>
+Date: Wed, 31 Aug 2022 14:13:54 +0800
+Subject: [PATCH] Video: Remove Main/Main10 profile limit
+
+This will consider all HEVC profile as to supported, and
+help you be able to play video's like HEVC Rext, SCC etc...
+---
+ media/base/supported_types.cc | 20 --------------------
+ 1 file changed, 20 deletions(-)
+
+diff --git a/media/base/supported_types.cc b/media/base/supported_types.cc
+index 287af88e744a0..cc28d84b262fe 100644
+--- a/media/base/supported_types.cc
++++ b/media/base/supported_types.cc
+@@ -205,27 +205,7 @@ bool IsHevcProfileSupported(const VideoType& type) {
+     return false;
+ 
+ #if BUILDFLAG(ENABLE_PLATFORM_HEVC)
+-#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_LINUX) || \
+-    BUILDFLAG(IS_MAC)
+-#if BUILDFLAG(IS_CHROMEOS_LACROS)
+-  // TODO(b/171813538): For Lacros, the supplemental profile cache will be
+-  // asking lacros-gpu, but we will be doing decoding in ash-gpu. Until the
+-  // codec detection is plumbed through to ash-gpu we can do this extra check
+-  // for HEVC support.
+-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+-          switches::kLacrosEnablePlatformHevc)) {
+-    return true;
+-  }
+-#endif  // BUILDFLAG(IS_CHROMEOS_LACROS)
+-  return GetSupplementalProfileCache()->IsProfileSupported(type.profile);
+-#elif BUILDFLAG(IS_ANDROID)
+-  // Technically android 5.0 mandates support for only HEVC main profile,
+-  // however some platforms (like chromecast) have had more profiles supported
+-  // so we'll see what happens if we just enable them all.
+-  return base::FeatureList::IsEnabled(kPlatformHEVCDecoderSupport);
+-#else
+   return true;
+-#endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_LINUX)
+ #else
+   return false;
+ #endif  // BUILDFLAG(ENABLE_PLATFORM_HEVC)
+-- 
+2.32.1 (Apple Git-133)
+

--- a/remove-main-main10-profile-limit.patch
+++ b/remove-main-main10-profile-limit.patch
@@ -1,24 +1,12 @@
-From f8a2a66134bb127bfde54db3e0575b7636e93441 Mon Sep 17 00:00:00 2001
-From: Sta Zhu <zhusidayoyo@hotmail.com>
-Date: Wed, 31 Aug 2022 14:13:54 +0800
-Subject: [PATCH] Video: Remove Main/Main10 profile limit
-
-This will consider all HEVC profile as to supported, and
-help you be able to play video's like HEVC Rext, SCC etc...
----
- media/base/supported_types.cc | 20 --------------------
- 1 file changed, 20 deletions(-)
-
 diff --git a/media/base/supported_types.cc b/media/base/supported_types.cc
-index 287af88e744a0..cc28d84b262fe 100644
+index c2efcdb..cc28d84 100644
 --- a/media/base/supported_types.cc
 +++ b/media/base/supported_types.cc
-@@ -205,27 +205,7 @@ bool IsHevcProfileSupported(const VideoType& type) {
+@@ -205,34 +205,7 @@ bool IsHevcProfileSupported(const VideoType& type) {
      return false;
  
  #if BUILDFLAG(ENABLE_PLATFORM_HEVC)
--#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_LINUX) || \
--    BUILDFLAG(IS_MAC)
+-#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_LINUX)
 -#if BUILDFLAG(IS_CHROMEOS_LACROS)
 -  // TODO(b/171813538): For Lacros, the supplemental profile cache will be
 -  // asking lacros-gpu, but we will be doing decoding in ash-gpu. Until the
@@ -30,6 +18,14 @@ index 287af88e744a0..cc28d84b262fe 100644
 -  }
 -#endif  // BUILDFLAG(IS_CHROMEOS_LACROS)
 -  return GetSupplementalProfileCache()->IsProfileSupported(type.profile);
+-#elif BUILDFLAG(IS_MAC)
+-  if (__builtin_available(macOS 11.0, *))
+-    return base::FeatureList::IsEnabled(kPlatformHEVCDecoderSupport) &&
+-           (type.profile == HEVCPROFILE_MAIN ||
+-            type.profile == HEVCPROFILE_MAIN10 ||
+-            type.profile == HEVCPROFILE_MAIN_STILL_PICTURE ||
+-            type.profile == HEVCPROFILE_REXT);
+-  return false;
 -#elif BUILDFLAG(IS_ANDROID)
 -  // Technically android 5.0 mandates support for only HEVC main profile,
 -  // however some platforms (like chromecast) have had more profiles supported
@@ -41,6 +37,3 @@ index 287af88e744a0..cc28d84b262fe 100644
  #else
    return false;
  #endif  // BUILDFLAG(ENABLE_PLATFORM_HEVC)
--- 
-2.32.1 (Apple Git-133)
-


### PR DESCRIPTION
Recently I found some sites that were providing HEVC where I was unable to see any video, just audio. Turns out chromium supports HEVC since 104 but it's not enabled by default (at least in chromium/linux).
With the following changes, HEVC software decoding is possible through ffmpeg.
I was not able to make VAAPI work with my GPU (6700 XT). Maybe intel-media-driver works better, need some testing for that.
HEVC software decoding is kinda demanding, but at least software decoding is better than no decoding.

Site that I found that support HEVC: https://2chen.moe/
More concrete example: https://2chen.moe/tv/1807601#p1807638

Edit:
patch was obtained from here: https://github.com/StaZhu/enable-chromium-hevc-hardware-decoding