### PR TITLE
use pacman as advised by arch wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ echo '
 [home_ungoogled_chromium_Arch]
 SigLevel = Required TrustAll
 Server = https://download.opensuse.org/repositories/home:/ungoogled_chromium/Arch/$arch' | sudo tee --append /etc/pacman.conf
-sudo pacman -Sy
+sudo pacman -Syu
 ```
 
 Use this command to install ungoogled-chromium:
 
 ```sh
-sudo pacman -Sy ungoogled-chromium
+sudo pacman -S ungoogled-chromium
 ```
 
 ### Unofficial Repositories


### PR DESCRIPTION
From the [arch wiki](https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported):

> Do **not** use:
> - `pacman -Sy _package_`
>
> . . .
>
> When refreshing the package database, **always** do a full upgrade with `pacman -Syu`

The installation instructions on the README for adding the OBS repo and installing ungoogled chromium are currently inconsistent with the arch wiki's guidelines.

Link to arch wiki page:
https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported