### PR TITLE
Enable PGO when using prebuilt clang

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,9 +10,9 @@
 
 pkgname=ungoogled-chromium
 pkgver=121.0.6167.160
-pkgrel=1
+pkgrel=2
 _launcher_ver=8
-_system_clang=1
+: ${_system_clang:=1}
 # ungoogled chromium variables
 _uc_usr=ungoogled-software
 _uc_ver=121.0.6167.160-1
@@ -257,6 +257,10 @@ build() {
     _flags+=(
       'rust_sysroot_absolute="/usr"'
       "rustc_version=\"$(rustc --version)\""
+    )
+  else
+    _flags+=(
+      'chrome_pgo_phase=2'
     )
   fi
 


### PR DESCRIPTION
This PR enables PGO when the prebuilt clang is used.  Switching to the prebuilt clang alone is insufficient because PGO is off by default.  This PR also enables using the prebuilt clang without editing the PKGBUILD by presetting the variable.  (eg, `_system_clang=0 makepkg`)