### PR TITLE
PKGBUILD: Add missing Vulkan library to fix VA-API

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,7 +10,7 @@
 
 pkgname=ungoogled-chromium
 pkgver=126.0.6478.126
-pkgrel=1
+pkgrel=2
 _launcher_ver=8
 _system_clang=1
 # ungoogled chromium variables
@@ -332,6 +332,7 @@ package() {
 
     # SwiftShader ICD
     libvk_swiftshader.so
+    libvulkan.so.1
     vk_swiftshader_icd.json
   )
 


### PR DESCRIPTION
The PKGBUILD is missing a Vulkan library required for VA-API usage. It is already included in the official Arch Linux package.