### PR TITLE
PKGBUILD: Fix symlink creation for node

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -156,7 +156,7 @@ prepare() {
     -f "$_ungoogled_repo/domain_substitution.list" -c domainsubcache.tar.gz ./
 
   # Link to system tools required by the build
-  rm -f third_party/node/linux/node-linux-x64/bin/node
+  mkdir -p third_party/node/linux/node-linux-x64/bin/
   ln -s /usr/bin/node third_party/node/linux/node-linux-x64/bin/
   ln -s /usr/bin/java third_party/jdk/current/bin/
 


### PR DESCRIPTION
With https://github.com/ungoogled-software/ungoogled-chromium/commit/9258f5d286bf12ec1aa41feaacdec89295175a05 the directory `third_party/node/linux/` is removed during pruning and needs to be recreated in order to link the system node binary.