### PR TITLE
#308 PKGBUILD: Fix symlink creation for jdk

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -155,9 +155,10 @@ prepare() {
 
   # Link to system tools required by the build
   if (( ! _manual_clone )); then
-    mkdir -p third_party/node/linux/node-linux-x64/bin/ third_party/jdk/current/bin/
+    mkdir -p third_party/node/linux/node-linux-x64/bin/
     ln -s /usr/bin/node third_party/node/linux/node-linux-x64/bin/
   fi
+  ln -s third_party/jdk/current/bin/
   ln -s /usr/bin/java third_party/jdk/current/bin/
 
   # Remove bundled libraries for which we will use the system copies; this

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -158,7 +158,7 @@ prepare() {
     mkdir -p third_party/node/linux/node-linux-x64/bin/
     ln -s /usr/bin/node third_party/node/linux/node-linux-x64/bin/
   fi
-  ln -s third_party/jdk/current/bin/
+  mkdir -p third_party/jdk/current/bin/
   ln -s /usr/bin/java third_party/jdk/current/bin/
 
   # Remove bundled libraries for which we will use the system copies; this


### PR DESCRIPTION
build failed with
` 
ln: failed to create symbolic link 'third_party/jdk/current/bin/': No such file or directory
`
With  https://github.com/ungoogled-software/ungoogled-chromium/commit/9258f5d286bf12ec1aa41feaacdec89295175a05 creation of third_party symlink for node moved under _manual_clone condition, but seems by mistake, because java dir creation for symlink also has been moved under condition, but symlink creation still used without condition.
By this PR trying to fix it