### PR TITLE
PKGBUILD: Ensure used correct rust toolchain

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -104,6 +104,7 @@ depends+=(${_system_libs[@]})
 
 prepare() {
   rustup toolchain install 1.91.0
+  rustup default 1.91.0
 
   if (( _manual_clone )); then
     ./fetch-chromium-release $pkgver


### PR DESCRIPTION
When installing a toolchain without setting `default_toolchain`, it will use the toolchain defined in `$HOME/.rustup/setting.toml`. It only used the correct toolchain when building in CI, because no rust toolchain is installed by default